### PR TITLE
Replace node-wget with wget-improved

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -32,17 +32,23 @@ if ((process.platform == "win32") || (process.platform == "darwin")) {
 }
 
 function getExtractUnar(urlsource, filesource, destination){
-    var node_wget = require('node-wget');
+    var node_wget = require("wget-improved");
     var unzip = require('unzipper');
     console.log('Downloading ' + urlsource);
-  return new Promise(function (resolve, reject) {         
-    node_wget({ url: urlsource, dest: filesource }, function (err) {
-        if (err) { return reject('Error downloading file: ' + err); }
+  return new Promise(function (resolve, reject) { 
+
+    let download = node_wget.download(urlsource, filesource, {});
+    download.on('error', function(err) {
+        console.error('Error downloading file: ' + err);
+        reject(err);
+    });
+    download.on('end', function(output) {
         var unzipfile = unzip.Extract({ path: destination });
         unzipfile.on('error', function(err) { reject(err); });
         unzipfile.on('close', function() { resolve(); });
         fs.createReadStream(filesource).pipe(unzipfile);     
-    });        
+    });
+
   });
 } 
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npmlog": "^4.1.2"
   },
   "optionalDependencies": {
-    "node-wget": "^0.4.2",
+    "wget-improved": "^3.2.1",
     "system-installer": "^1.1.0",
     "unzipper": "^0.10.1"
   },


### PR DESCRIPTION
Same as node-7zforall.  Ran `npm audit` and no audit problem..

Associated fix for 7zforall.. https://github.com/techno-express/node-7z/pull/11